### PR TITLE
#26 rebase to ubuntu resolute

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -29,9 +29,8 @@ jobs:
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> External trigger running off of master branch. To disable this trigger, add \`filezilla_master\` into the Github organizational variable \`SKIP_EXTERNAL_TRIGGER\`." >> $GITHUB_STEP_SUMMARY
           printf "\n## Retrieving external version\n\n" >> $GITHUB_STEP_SUMMARY
-          EXT_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
-            && awk '/^P:'"filezilla"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://')
-          echo "Type is \`alpine_repo\`" >> $GITHUB_STEP_SUMMARY
+          EXT_RELEASE=$(curl -s -L https://archive.ubuntu.com/ubuntu/dists/resolute/universe/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: filezilla' | awk -F ': ' '/Version/{print $2;exit}')
+          echo "Type is \`custom_version_command\`" >> $GITHUB_STEP_SUMMARY
           if grep -q "^filezilla_master_${EXT_RELEASE}" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
             echo "> Github organizational variable \`SKIP_EXTERNAL_TRIGGER\` matches current external release; skipping trigger." >> $GITHUB_STEP_SUMMARY
@@ -106,13 +105,6 @@ jobs:
           echo "Last pushed version: \`${IMAGE_VERSION}\`" >> $GITHUB_STEP_SUMMARY
           if [ "${EXT_RELEASE_SANITIZED}" == "${IMAGE_VERSION}" ]; then
             echo "Sanitized version \`${EXT_RELEASE_SANITIZED}\` already pushed, exiting" >> $GITHUB_STEP_SUMMARY
-            exit 0
-          elif [[ $(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.22/community/aarch64/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"filezilla"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]; then
-            echo "New version \`${EXT_RELEASE}\` found; but not all arch repos updated yet; exiting" >> $GITHUB_STEP_SUMMARY
-            FAILURE_REASON="New version ${EXT_RELEASE} for filezilla tag latest is detected, however not all arch repos are updated yet. Will try again later."
-            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
-              "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n"}],
-              "username": "Github Actions"}' ${{ secrets.DISCORD_WEBHOOK }}
             exit 0
           elif [ $(curl -s https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-filezilla/job/master/lastBuild/api/json | jq -r '.building') == "true" ]; then
             echo "New version \`${EXT_RELEASE}\` found; but there already seems to be an active build on Jenkins; exiting" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-selkies:alpine323
+FROM ghcr.io/linuxserver/baseimage-selkies:ubunturesolute
 
 # set version label
 ARG BUILD_DATE
@@ -20,15 +20,16 @@ RUN \
     /usr/share/selkies/www/icon.png \
     https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/filezilla-logo.png && \
   echo "**** install packages ****" && \
-  if [ -z ${FILEZILLA_VERSION+x} ]; then \
-    FILEZILLA_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
-    && awk '/^P:filezilla$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
-  fi && \
-  apk add --no-cache \
-    filezilla==${FILEZILLA_VERSION} \
-    filezilla-lang && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    filezilla${FILEZILLA_VERSION:+=$FILEZILLA_VERSION} && \
   echo "**** cleanup ****" && \
+  apt-get autoclean && \
   rm -rf \
+    /config/.cache \
+    /config/.launchpadlib \
+    /var/lib/apt/lists/* \
+    /var/tmp/* \
     /tmp/*
 
 # add local files

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-alpine323
+FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-ubunturesolute
 
 # set version label
 ARG BUILD_DATE
@@ -20,15 +20,16 @@ RUN \
     /usr/share/selkies/www/icon.png \
     https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/filezilla-logo.png && \
   echo "**** install packages ****" && \
-  if [ -z ${FILEZILLA_VERSION+x} ]; then \
-    FILEZILLA_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
-    && awk '/^P:filezilla$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
-  fi && \
-  apk add --no-cache \
-    filezilla==${FILEZILLA_VERSION} \
-    filezilla-lang && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    filezilla${FILEZILLA_VERSION:+=$FILEZILLA_VERSION} && \
   echo "**** cleanup ****" && \
+  apt-get autoclean && \
   rm -rf \
+    /config/.cache \
+    /config/.launchpadlib \
+    /var/lib/apt/lists/* \
+    /var/tmp/* \
     /tmp/*
 
 # add local files

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,16 +26,14 @@ pipeline {
     DOCKERHUB_IMAGE = 'linuxserver/filezilla'
     DEV_DOCKERHUB_IMAGE = 'lsiodev/filezilla'
     PR_DOCKERHUB_IMAGE = 'lspipepr/filezilla'
-    DIST_IMAGE = 'alpine'
-    DIST_TAG = '3.22'
-    DIST_REPO = 'http://dl-cdn.alpinelinux.org/alpine/v3.22/community/'
-    DIST_REPO_PACKAGES = 'filezilla'
+    DIST_IMAGE = 'ubuntu'
     MULTIARCH = 'true'
     CI = 'true'
     CI_WEB = 'true'
     CI_PORT = '3001'
     CI_SSL = 'true'
     CI_DELAY = '120'
+    CI_WEB_SCREENSHOT_DELAY='30'
     CI_DOCKERENV = 'TZ=US/Pacific'
     CI_AUTH = 'user:password'
     CI_WEBPATH = ''
@@ -147,15 +145,14 @@ pipeline {
     /* ########################
        External Release Tagging
        ######################## */
-    // If this is an alpine repo change for external version determine an md5 from the version string
-    stage("Set tag Alpine Repo"){
+    // If this is a custom command to determine version use that command
+    stage("Set tag custom bash"){
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: '''curl -sL "${DIST_REPO}x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
-                       && awk '/^P:'"${DIST_REPO_PACKAGES}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://' ''',
+            script: ''' curl -s -L https://archive.ubuntu.com/ubuntu/dists/resolute/universe/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: filezilla' | awk -F ': ' '/Version/{print $2;exit}' ''',
             returnStdout: true).trim()
-            env.RELEASE_LINK = 'alpine_repo'
+            env.RELEASE_LINK = 'custom_command'
         }
       }
     }
@@ -898,6 +895,7 @@ pipeline {
                 --shm-size=1gb \
                 -v /var/run/docker.sock:/var/run/docker.sock \
                 -e IMAGE=\"${IMAGE}\" \
+                -e WEB_SCREENSHOT_DELAY=\"${CI_WEB_SCREENSHOT_DELAY}\" \
                 -e DOCKER_LOGS_TIMEOUT=\"${CI_DELAY}\" \
                 -e TAGS=\"${CI_TAGS}\" \
                 -e META_TAG=\"${META_TAG}\" \
@@ -1037,7 +1035,7 @@ pipeline {
                   "type": "commit",\
                   "tagger": {"name": "LinuxServer-CI","email": "ci@linuxserver.io","date": "'${GITHUB_DATE}'"}}'
               echo "Pushing New release for Tag"
-              echo "Updating external repo packages to ${EXT_RELEASE_CLEAN}" > releasebody.json
+              echo "Updating to ${EXT_RELEASE_CLEAN}" > releasebody.json
               jq -n \
                 --arg tag_name "$META_TAG" \
                 --arg target_commitish "master" \

--- a/README.md
+++ b/README.md
@@ -129,6 +129,63 @@ For Intel and AMD GPUs.
       - DRINODE=/dev/dri/renderD128
       - DRI_NODE=/dev/dri/renderD128
 ```
+
+##### Nvidia (Proprietary Drivers)
+
+**Note: Nvidia support is not available for Alpine-based images.**
+
+**Prerequisites:**
+
+1. **Driver:** Proprietary drivers **580 or higher** are required. **Crucially, you should install the driver using the `.run` file downloaded directly from the Nvidia website.**
+    * **Unraid:** Use the production branch from the Nvidia Driver Plugin.
+
+2. **Kernel Parameter:** You must set `nvidia-drm.modeset=1 nvidia_drm.fbdev=1` in your host bootloader.
+    * **Standard Linux (GRUB):** Edit `/etc/default/grub` and add the parameter to your existing `GRUB_CMDLINE_LINUX_DEFAULT` line:
+
+        ```text
+        GRUB_CMDLINE_LINUX_DEFAULT="<other existing options> nvidia-drm.modeset=1 nvidia_drm.fbdev=1"
+        ```
+
+        Then apply the changes by running:
+
+        ```bash
+        sudo update-grub
+        ```
+
+    * **Unraid (Syslinux):** Edit the file `/boot/syslinux/syslinux.cfg` and add `nvidia-drm.modeset=1 nvidia_drm.fbdev=1` to the end of the `append` line for the Unraid OS boot entry.
+
+3. **Hardware Initialization:** **On headless systems, the Nvidia video card requires a physical dummy plug inserted into the GPU so that DRM initializes properly.**
+
+4. **Docker Runtime:** Configure the host docker daemon to use the Nvidia runtime:
+
+    ```bash
+    sudo nvidia-ctk runtime configure --runtime=docker
+    sudo systemctl restart docker
+    ```
+
+**Compose Configuration:**
+
+```yaml
+---
+services:
+  filezilla:
+    image: lscr.io/linuxserver/filezilla:latest
+    environment:
+      - PIXELFLUX_WAYLAND=true
+      # Ensure these point to the rendered node injected by the runtime (usually renderD128)
+      - DRINODE=/dev/dri/renderD128
+      - DRI_NODE=/dev/dri/renderD128
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [compute,video,graphics,utility]
+```
+
+* **Unraid:** Ensure you're properly setting the DRINODE/DRI_NODE and adding `--gpus all --runtime nvidia` to your extra parameters.
+
 ### SealSkin Compatibility
 
 This container is compatible with [SealSkin](https://sealskin.app).
@@ -586,6 +643,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **20.05.26:** - Rebase to Ubuntu Resolute.
 * **03.04.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **28.12.25:** - Add Wayland init logic, rebase to Alpine 3.23.
 * **26.07.25:** - Rebase to Selkies and Alpine 3.22, HTTPS IS NOW REQUIRED.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,8 @@
 
 # jenkins variables
 project_name: docker-filezilla
-external_type: alpine_repo
+external_type: na
+custom_version_command: "curl -s -L https://archive.ubuntu.com/ubuntu/dists/resolute/universe/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: filezilla' | awk -F ': ' '/Version/{print $2;exit}'"
 release_type: stable
 release_tag: latest
 ls_branch: master
@@ -15,16 +16,14 @@ repo_vars:
   - DOCKERHUB_IMAGE = 'linuxserver/filezilla'
   - DEV_DOCKERHUB_IMAGE = 'lsiodev/filezilla'
   - PR_DOCKERHUB_IMAGE = 'lspipepr/filezilla'
-  - DIST_IMAGE = 'alpine'
-  - DIST_TAG = '3.22'
-  - DIST_REPO = 'http://dl-cdn.alpinelinux.org/alpine/v3.22/community/'
-  - DIST_REPO_PACKAGES = 'filezilla'
+  - DIST_IMAGE = 'ubuntu'
   - MULTIARCH = 'true'
   - CI = 'true'
   - CI_WEB = 'true'
   - CI_PORT = '3001'
   - CI_SSL = 'true'
   - CI_DELAY = '120'
+  - CI_WEB_SCREENSHOT_DELAY='30'
   - CI_DOCKERENV = 'TZ=US/Pacific'
   - CI_AUTH = 'user:password'
   - CI_WEBPATH = ''

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -28,6 +28,7 @@ custom_params:
   - {name: "shm-size", name_compose: "shm_size", value: "1gb", desc: "Recommended for all desktop images."}
 # Selkies blurb settings
 selkies_blurb: true
+show_nvidia: true
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
@@ -102,6 +103,7 @@ init_diagram: |
   "filezilla:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "20.05.26:", desc: "Rebase to Ubuntu Resolute."}
   - {date: "03.04.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "28.12.25:", desc: "Add Wayland init logic, rebase to Alpine 3.23."}
   - {date: "26.07.25:", desc: "Rebase to Selkies and Alpine 3.22, HTTPS IS NOW REQUIRED."}


### PR DESCRIPTION
https://github.com/linuxserver/docker-filezilla/issues/26

It seems like Alpine suffers from the same wlroots/labwc combination issue as Ubuntu resolute, pixman path with labwc can get buggy when resized a bunch. For resolute we compile from source specific versions that bypass this https://github.com/linuxserver/docker-baseimage-selkies/blob/ubunturesolute/Dockerfile#L92-L271, I do not want to do this for Alpine it is better to rebase and this adds nvidia support if that matters. 